### PR TITLE
Feature: Deploy service to Heroku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 logs/*.log
 .nyc_output/
 coverage/
+build

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+# This file is for Heroku deployments
+
+web: node dist/src/index.js

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This starter kit comes with the following features:
 - **Dockerfile + docker-compose for development**
 - **Basic Test Suite with Tape**
 - **Coverage Report**
+- **Supports Heroku Deployment**
 
 ## Requirements
 
@@ -29,6 +30,7 @@ This starter kit comes with the following features:
 3. Run `npm run nodemon:start`
 4. Visit [http://localhost:8080/documentation](http://localhost:8080/documentation) to view swagger docs.
 5. Visit [http://localhost:8080/api/users](http://localhost:8080/api/users) to test the REST API.
+6. Visit [http://localhost:8080/status](http://localhost:8080/status) to view the status monitor.
 
 OUTDATED: Now there's a CLI that currently support creating a new project from this repo: [create-typescript-api](https://github.com/BlackBoxVision/create-typescript-api)
 
@@ -43,6 +45,23 @@ This is not finished, there's still a lot of things to improve. Here you got som
 - [ ] Add support for Auth with JWT or Sessions
 - [ ] Add support for TypeORM/Mongoose
 - [ ] Add support for Jenkins pipeline
+
+## Documentation
+
+### What are the package.json scripts for?
+
+* `build-ts`: Compiles typescript based on config set in tsconfig.json.
+* `start`: Starts node with the compiled typescript. Used by eg. Heroku.
+* `docker:logs`: View Docker logs
+* `docker:ps`: List Docker containers
+* `docker:start`: Start Docker container based on docker-compose.yml file.
+* `docker:stop`: Stop Docker container
+* `nodemon:build`: Starts the Nodemon using ts-node. No need to compile beforehand.
+* `nodemon:start`: Same as nodemon:build
+* `format:lint`: Runs tslint on the typescipt files, based on tslint.js settings.
+* `format:prettier`: Runs prettier on all ts-files.
+* `postinstall`: Runs build-ts script. This is used by eg. Heroku automatically.
+* `test`: Runs tests using nyc, and creates coverage report.
 
 ## Issues
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "node" : ">=10.0" 
   }, 
   "scripts": {
+    "start": "./node_modules/.bin/tsc --module commonjs --allowJs --outDir build/ --sourceMap --target es6 src/index.ts && node build/index.js",
     "docker:logs": "docker-compose logs",
     "docker:ps": "docker-compose ps",
     "docker:start": "docker-compose up",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "node" : ">=10.0" 
   }, 
   "scripts": {
-    "start": "./node_modules/.bin/tsc --module commonjs --allowJs --outDir build/ --sourceMap --target es6 src/index.ts && node build/index.js",
+    "build-ts": "tsc",
+    "start": "node dist/src/index.js",
     "docker:logs": "docker-compose logs",
     "docker:ps": "docker-compose ps",
     "docker:start": "docker-compose up",
@@ -21,6 +22,7 @@
     "nodemon:start": "npm run nodemon:build",
     "format:lint": "./node_modules/.bin/tslint -c tslint.json 'src/**/*.ts'",
     "format:prettier": "./node_modules/.bin/prettier --tab-width 4 --print-width 120 --single-quote --trailing-comma all --write 'src/**/*.ts'",
+    "postinstall": "npm run build-ts",
     "test": "NODE_ENV=test nyc --reporter=lcov --require ts-node/register tape test/**/*.spec.{ts,js} | tap-spec"
   },
   "nyc": {
@@ -32,6 +34,13 @@
     ]
   },
   "dependencies": {
+    "@types/code": "^4.0.5",
+    "@types/dotenv": "^6.1.0",
+    "@types/hapi": "^17.8.2",
+    "@types/joi": "^14.0.1",
+    "@types/nedb": "^1.8.3",
+    "@types/node": "^10.12.18",
+    "@types/tape": "^4.2.33",
     "hapi": "^17.8.1",
     "hapi-boom-decorators": "^4.1.2",
     "hapi-swagger": "^9.3.0",
@@ -40,17 +49,10 @@
     "joi": "^14.3.1",
     "nedb": "^1.8.0",
     "vision": "^5.4.4",
-    "winston": "^3.1.0"
+    "winston": "^3.1.0",
+    "dotenv": "^6.2.0"
   },
   "devDependencies": {
-    "@types/code": "^4.0.5",
-    "@types/dotenv": "^6.1.0",
-    "@types/hapi": "^17.8.2",
-    "@types/joi": "^14.0.1",
-    "@types/nedb": "^1.8.3",
-    "@types/node": "^10.12.18",
-    "@types/tape": "^4.2.33",
-    "dotenv": "^6.2.0",
     "nodemon": "^1.11.0",
     "nyc": "^13.1.0",
     "prettier": "^1.5.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import Logger from './helper/logger';
 process.on('SIGINT', () => {
     Logger.info('Stopping hapi server');
 
-    Server.stop().then((err) => {
+    Server.stop().then(err => {
         Logger.info(`Server stopped`);
         process.exit(err ? 1 : 0);
     });

--- a/src/model/user.ts
+++ b/src/model/user.ts
@@ -1,6 +1,18 @@
 export default class User {
+    
     public _id: string;
-    public age: string;
+    public age: Number;
     public name: string;
     public lastName: string;
+
+    constructor(name: string) {
+        this._id = "test";
+        this.name = name;
+        this.age = 12;
+        this.lastName = "Smith";
+    }
+
+    toString() {
+        return `UserID: ${this._id}, Age: ${this.age}, Name: ${this.name}, LastName: ${this.lastName}`;
+    }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,6 @@ export default class Server {
             });
 
             Server._instance = new Hapi.Server({
-                host: process.env.HOST,
                 port: process.env.PORT,
             });
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -16,7 +16,7 @@ export const startServer = async (): Promise<Hapi.Server> => {
     return await Server.recycle();
 };
 
-export const stopServer = async (): Promise<void> => {
+export const stopServer = async (): Promise<void | Error> => {
     return await Server.stop();
 };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -51,6 +51,7 @@
   },
   "exclude": [
     "node_modules",
-    "**/*.spec.ts"
+    "**/*.spec.ts",
+    "dist"
   ]
 }


### PR DESCRIPTION
I thought it would be useful to make the project Heroku-compatible, as it's many people's hosting choice.

Changes done here:
* Added necessary npm scripts that are needed by Heroku (npm start & npm run postinstall).
* Moved library dependencies to right place, because I noticed Heroku deployment didn't work when some dependencies were only in the dev-side.
* Updated the server.ts to not include host (before this the server start crashed the app in Heroku).
* Running tsc caused errors, so I fixed those.
* Updated readme.